### PR TITLE
Remove extraneous whitespace from transpiler.

### DIFF
--- a/glsl/src/transpiler/glsl.rs
+++ b/glsl/src/transpiler/glsl.rs
@@ -1330,8 +1330,8 @@ where
 }
 
 pub fn show_statement<F>(f: &mut F, st: &syntax::Statement)
-  where
-      F: Write,
+where
+  F: Write,
 {
   show_statement_spaced(f, st, false)
 }
@@ -1797,18 +1797,18 @@ mod tests {
   fn ternary_parentheses() {
     assert_eq!(
       to_string(&expr("a ? b : c ? d : e").unwrap().1),
-      "a ? b : c ? d : e"
+      "a?b:c?d:e"
     );
     assert_eq!(
       to_string(&expr("(a ? b : c) ? d : e").unwrap().1),
-      "(a ? b : c) ? d : e"
+      "(a?b:c)?d:e"
     );
   }
 
   #[test]
   fn assignment_parentheses() {
-    assert_eq!(to_string(&expr("a = b = c").unwrap().1), "a = b = c");
-    assert_eq!(to_string(&expr("(a = b) = c").unwrap().1), "(a = b) = c");
+    assert_eq!(to_string(&expr("a = b = c").unwrap().1), "a=b=c");
+    assert_eq!(to_string(&expr("(a = b) = c").unwrap().1), "(a=b)=c");
   }
 
   #[test]

--- a/glsl/src/transpiler/glsl.rs
+++ b/glsl/src/transpiler/glsl.rs
@@ -1448,7 +1448,7 @@ where
       show_statement_spaced(f, body, true);
       let _ = f.write_str("while(");
       show_expr(f, cond);
-      let _ = f.write_str(")");
+      let _ = f.write_str(");");
     }
     syntax::IterationStatement::For(ref init, ref rest, ref body) => {
       let _ = f.write_str("for(");
@@ -1485,6 +1485,7 @@ where
       if let Some(ref e) = *expr {
         show_expr(f, e);
       }
+      let _ = f.write_str(";");
     }
     syntax::ForInitStatement::Declaration(ref d) => show_declaration(f, d),
   }
@@ -1831,8 +1832,52 @@ return u;
 }
 "#;
 
-    // Ideally we would use SRC as the expected, but there's a bug in block braces generation
     const DST: &'static str = r#"vec2 main(){float n=0.;float p=0.;float u=vec2(0.,0.);if(n-p>0.&&u.y<n&&u.y>p){}return u;}"#;
+
+    let mut s = String::new();
+    show_function_definition(&mut s, &function_definition(SRC).unwrap().1);
+
+    assert_eq!(s, DST);
+  }
+
+  #[test]
+  fn test_do_statement() {
+    use crate::parsers::function_definition;
+
+    const SRC: &'static str = r#"void main() {
+  do { } while (true);
+  do {
+    a();
+  } while (true);
+  do {
+    a();
+    b();
+  } while (true);
+}
+"#;
+
+    const DST: &'static str = r#"void main(){do{}while(true);do a();while(true);do{a();b();}while(true);}"#;
+
+    let mut s = String::new();
+    show_function_definition(&mut s, &function_definition(SRC).unwrap().1);
+
+    assert_eq!(s, DST);
+  }
+
+  #[test]
+  fn test_for_statement() {
+    use crate::parsers::function_definition;
+
+    const SRC: &'static str = r#"void main() {
+  int i = 0;
+  for(;;) { }
+  for(i = 0;; ) { }
+  for(int i = 0; i < 10;) { }
+  for(int i = 0; i < 10; i++) { }
+}
+"#;
+
+    const DST: &'static str = r#"void main(){int i=0;for(;;){}for(i=0;;){}for(int i=0;i<10;){}for(int i=0;i<10;i++){}}"#;
 
     let mut s = String::new();
     show_function_definition(&mut s, &function_definition(SRC).unwrap().1);

--- a/glsl/src/transpiler/glsl.rs
+++ b/glsl/src/transpiler/glsl.rs
@@ -491,7 +491,7 @@ where
     let _ = write!(f, "{} ", name);
   }
 
-  let _ = f.write_str("{\n");
+  let _ = f.write_str("{");
 
   for field in &s.fields.0 {
     show_struct_field(f, field);
@@ -505,7 +505,7 @@ where
   F: Write,
 {
   show_struct_non_declaration(f, s);
-  let _ = f.write_str(";\n");
+  let _ = f.write_str(";");
 }
 
 pub fn show_struct_field<F>(f: &mut F, field: &syntax::StructFieldSpecifier)
@@ -528,11 +528,11 @@ where
 
   // write the rest of the identifiers
   for identifier in identifiers {
-    let _ = f.write_str(", ");
+    let _ = f.write_str(",");
     show_arrayed_identifier(f, identifier);
   }
 
-  let _ = f.write_str(";\n");
+  let _ = f.write_str(";");
 }
 
 pub fn show_array_spec<F>(f: &mut F, a: &syntax::ArraySpecifier)
@@ -839,9 +839,9 @@ where
         show_expr(f, &c);
         let _ = f.write_str(")");
       }
-      let _ = f.write_str(" ? ");
+      let _ = f.write_str("?");
       show_expr(f, &s);
-      let _ = f.write_str(" : ");
+      let _ = f.write_str(":");
       if e.precedence() <= expr.precedence() {
         show_expr(f, &e);
       } else {
@@ -861,9 +861,7 @@ where
         let _ = f.write_str(")");
       }
 
-      let _ = f.write_str(" ");
       show_assignment_op(f, &op);
-      let _ = f.write_str(" ");
 
       if e.precedence() <= op.precedence() {
         show_expr(f, &e);
@@ -896,7 +894,7 @@ where
         show_expr(f, first);
 
         for e in args_iter {
-          let _ = f.write_str(", ");
+          let _ = f.write_str(",");
           show_expr(f, e);
         }
       }
@@ -953,7 +951,7 @@ where
         let _ = f.write_str(")");
       }
 
-      let _ = f.write_str(", ");
+      let _ = f.write_str(",");
 
       if b.precedence() < expr.precedence() {
         show_expr(f, &b);
@@ -1129,20 +1127,20 @@ where
   match *d {
     syntax::Declaration::FunctionPrototype(ref proto) => {
       show_function_prototype(f, &proto);
-      let _ = f.write_str(";\n");
+      let _ = f.write_str(";");
     }
     syntax::Declaration::InitDeclaratorList(ref list) => {
       show_init_declarator_list(f, &list);
-      let _ = f.write_str(";\n");
+      let _ = f.write_str(";");
     }
     syntax::Declaration::Precision(ref qual, ref ty) => {
       show_precision_qualifier(f, &qual);
       show_type_specifier(f, &ty);
-      let _ = f.write_str(";\n");
+      let _ = f.write_str(";");
     }
     syntax::Declaration::Block(ref block) => {
       show_block(f, &block);
-      let _ = f.write_str(";\n");
+      let _ = f.write_str(";");
     }
     syntax::Declaration::Global(ref qual, ref identifiers) => {
       show_type_qualifier(f, &qual);
@@ -1157,7 +1155,7 @@ where
         }
       }
 
-      let _ = f.write_str(";\n");
+      let _ = f.write_str(";");
     }
   }
 }
@@ -1178,7 +1176,7 @@ where
     show_function_parameter_declaration(f, first);
 
     for param in iter {
-      let _ = f.write_str(", ");
+      let _ = f.write_str(",");
       show_function_parameter_declaration(f, param);
     }
   }
@@ -1214,7 +1212,6 @@ where
   F: Write,
 {
   show_type_specifier(f, &p.ty);
-  let _ = f.write_str(" ");
   show_arrayed_identifier(f, &p.ident);
 }
 
@@ -1225,7 +1222,7 @@ where
   show_single_declaration(f, &i.head);
 
   for decl in &i.tail {
-    let _ = f.write_str(", ");
+    let _ = f.write_str(",");
     show_single_declaration_no_type(f, decl);
   }
 }
@@ -1246,7 +1243,7 @@ where
   }
 
   if let Some(ref initializer) = d.initializer {
-    let _ = f.write_str(" = ");
+    let _ = f.write_str("=");
     show_initializer(f, initializer);
   }
 }
@@ -1258,7 +1255,7 @@ where
   show_arrayed_identifier(f, &d.ident);
 
   if let Some(ref initializer) = d.initializer {
-    let _ = f.write_str(" = ");
+    let _ = f.write_str("=");
     show_initializer(f, initializer);
   }
 }
@@ -1273,15 +1270,15 @@ where
       let mut iter = list.0.iter();
       let first = iter.next().unwrap();
 
-      let _ = f.write_str("{ ");
+      let _ = f.write_str("{");
       show_initializer(f, first);
 
       for ini in iter {
-        let _ = f.write_str(", ");
+        let _ = f.write_str(",");
         show_initializer(f, ini);
       }
 
-      let _ = f.write_str(" }");
+      let _ = f.write_str("}");
     }
   }
 }
@@ -1293,11 +1290,10 @@ where
   show_type_qualifier(f, &b.qualifier);
   let _ = f.write_str(" ");
   show_identifier(f, &b.name);
-  let _ = f.write_str(" {");
+  let _ = f.write_str("{");
 
   for field in &b.fields {
     show_struct_field(f, field);
-    let _ = f.write_str("\n");
   }
   let _ = f.write_str("}");
 
@@ -1311,7 +1307,6 @@ where
   F: Write,
 {
   show_function_prototype(f, &fd.prototype);
-  let _ = f.write_str(" ");
   show_compound_statement(f, &fd.statement);
 }
 
@@ -1319,13 +1314,13 @@ pub fn show_compound_statement<F>(f: &mut F, cst: &syntax::CompoundStatement)
 where
   F: Write,
 {
-  let _ = f.write_str("{\n");
+  let _ = f.write_str("{");
 
   for st in &cst.statement_list {
     show_statement(f, st);
   }
 
-  let _ = f.write_str("}\n");
+  let _ = f.write_str("}");
 }
 
 pub fn show_statement<F>(f: &mut F, st: &syntax::Statement)
@@ -1361,16 +1356,16 @@ where
     show_expr(f, e);
   }
 
-  let _ = f.write_str(";\n");
+  let _ = f.write_str(";");
 }
 
 pub fn show_selection_statement<F>(f: &mut F, sst: &syntax::SelectionStatement)
 where
   F: Write,
 {
-  let _ = f.write_str("if (");
+  let _ = f.write_str("if(");
   show_expr(f, &sst.cond);
-  let _ = f.write_str(") {\n");
+  let _ = f.write_str("){");
   show_selection_rest_statement(f, &sst.rest);
 }
 
@@ -1381,11 +1376,11 @@ where
   match *sst {
     syntax::SelectionRestStatement::Statement(ref if_st) => {
       show_statement(f, if_st);
-      let _ = f.write_str("}\n");
+      let _ = f.write_str("}");
     }
     syntax::SelectionRestStatement::Else(ref if_st, ref else_st) => {
       show_statement(f, if_st);
-      let _ = f.write_str("} else ");
+      let _ = f.write_str("}else ");
       show_statement(f, else_st);
     }
   }
@@ -1395,15 +1390,15 @@ pub fn show_switch_statement<F>(f: &mut F, sst: &syntax::SwitchStatement)
 where
   F: Write,
 {
-  let _ = f.write_str("switch (");
+  let _ = f.write_str("switch(");
   show_expr(f, &sst.head);
-  let _ = f.write_str(") {\n");
+  let _ = f.write_str("){");
 
   for st in &sst.body {
     show_statement(f, st);
   }
 
-  let _ = f.write_str("}\n");
+  let _ = f.write_str("}");
 }
 
 pub fn show_case_label<F>(f: &mut F, cl: &syntax::CaseLabel)
@@ -1414,10 +1409,10 @@ where
     syntax::CaseLabel::Case(ref e) => {
       let _ = f.write_str("case ");
       show_expr(f, e);
-      let _ = f.write_str(":\n");
+      let _ = f.write_str(":");
     }
     syntax::CaseLabel::Def => {
-      let _ = f.write_str("default:\n");
+      let _ = f.write_str("default:");
     }
   }
 }
@@ -1428,23 +1423,23 @@ where
 {
   match *ist {
     syntax::IterationStatement::While(ref cond, ref body) => {
-      let _ = f.write_str("while (");
+      let _ = f.write_str("while(");
       show_condition(f, cond);
-      let _ = f.write_str(") ");
+      let _ = f.write_str(")");
       show_statement(f, body);
     }
     syntax::IterationStatement::DoWhile(ref body, ref cond) => {
-      let _ = f.write_str("do ");
+      let _ = f.write_str("do");
       show_statement(f, body);
-      let _ = f.write_str(" while (");
+      let _ = f.write_str("while(");
       show_expr(f, cond);
-      let _ = f.write_str(")\n");
+      let _ = f.write_str(")");
     }
     syntax::IterationStatement::For(ref init, ref rest, ref body) => {
-      let _ = f.write_str("for (");
+      let _ = f.write_str("for(");
       show_for_init_statement(f, init);
       show_for_rest_statement(f, rest);
-      let _ = f.write_str(") ");
+      let _ = f.write_str(")");
       show_statement(f, body);
     }
   }
@@ -1460,7 +1455,7 @@ where
       show_fully_specified_type(f, ty);
       let _ = f.write_str(" ");
       show_identifier(f, name);
-      let _ = f.write_str(" = ");
+      let _ = f.write_str("=");
       show_initializer(f, initializer);
     }
   }
@@ -1488,7 +1483,7 @@ where
     show_condition(f, cond);
   }
 
-  let _ = f.write_str("; ");
+  let _ = f.write_str(";");
 
   if let Some(ref e) = r.post_expr {
     show_expr(f, e);
@@ -1501,20 +1496,20 @@ where
 {
   match *j {
     syntax::JumpStatement::Continue => {
-      let _ = f.write_str("continue;\n");
+      let _ = f.write_str("continue;");
     }
     syntax::JumpStatement::Break => {
-      let _ = f.write_str("break;\n");
+      let _ = f.write_str("break;");
     }
     syntax::JumpStatement::Discard => {
-      let _ = f.write_str("discard;\n");
+      let _ = f.write_str("discard;");
     }
     syntax::JumpStatement::Return(ref e) => {
       let _ = f.write_str("return ");
       if let Some(e) = e {
         show_expr(f, e);
       }
-      let _ = f.write_str(";\n");
+      let _ = f.write_str(";");
     }
   }
 }
@@ -1822,17 +1817,7 @@ return u;
 "#;
 
     // Ideally we would use SRC as the expected, but there's a bug in block braces generation
-    const DST: &'static str = r#"vec2 main() {
-float n = 0.;
-float p = 0.;
-float u = vec2(0., 0.);
-if (n-p>0.&&u.y<n&&u.y>p) {
-{
-}
-}
-return u;
-}
-"#;
+    const DST: &'static str = r#"vec2 main(){float n=0.;float p=0.;float u=vec2(0.,0.);if(n-p>0.&&u.y<n&&u.y>p){{}}return u;}"#;
 
     let mut s = String::new();
     show_function_definition(&mut s, &function_definition(SRC).unwrap().1);

--- a/glsl/src/transpiler/glsl.rs
+++ b/glsl/src/transpiler/glsl.rs
@@ -1314,13 +1314,17 @@ pub fn show_compound_statement<F>(f: &mut F, cst: &syntax::CompoundStatement)
 where
   F: Write,
 {
-  let _ = f.write_str("{");
+  if cst.statement_list.len() != 1 {
+    let _ = f.write_str("{");
+  }
 
   for st in &cst.statement_list {
     show_statement(f, st);
   }
 
-  let _ = f.write_str("}");
+  if cst.statement_list.len() != 1 {
+    let _ = f.write_str("}");
+  }
 }
 
 pub fn show_statement<F>(f: &mut F, st: &syntax::Statement)
@@ -1365,7 +1369,7 @@ where
 {
   let _ = f.write_str("if(");
   show_expr(f, &sst.cond);
-  let _ = f.write_str("){");
+  let _ = f.write_str(")");
   show_selection_rest_statement(f, &sst.rest);
 }
 
@@ -1376,11 +1380,10 @@ where
   match *sst {
     syntax::SelectionRestStatement::Statement(ref if_st) => {
       show_statement(f, if_st);
-      let _ = f.write_str("}");
     }
     syntax::SelectionRestStatement::Else(ref if_st, ref else_st) => {
       show_statement(f, if_st);
-      let _ = f.write_str("}else ");
+      let _ = f.write_str("else ");
       show_statement(f, else_st);
     }
   }

--- a/glsl/src/transpiler/glsl.rs
+++ b/glsl/src/transpiler/glsl.rs
@@ -1886,6 +1886,81 @@ return u;
   }
 
   #[test]
+  fn test_ternary() {
+    use crate::parsers::function_definition;
+
+    const SRC: &'static str = r#"void main() {
+  float x = 0, y = 0, z = 0;
+  float w = (x ? x : z);
+  float q = y ? (z ? z : x) : z;
+}
+"#;
+
+    const DST: &'static str = r#"void main(){float x=0,y=0,z=0;float w=x?x:z;float q=y?z?z:x:z;}"#;
+
+    let mut s = String::new();
+    show_function_definition(&mut s, &function_definition(SRC).unwrap().1);
+
+    assert_eq!(s, DST);
+  }
+
+  #[test]
+  fn test_if_else() {
+    use crate::parsers::function_definition;
+
+    const SRC: &'static str = r#"void main() {
+  int i = 5;
+  if (i > 0) {
+  } else if (i < 5) {
+    a();
+  } else if (i < 1) {
+    a();
+    b();
+  } else {
+    a();
+  }
+}
+"#;
+
+    const DST: &'static str = r#"void main(){int i=5;if(i>0){}else if(i<5)a();else if(i<1){a();b();}else a();}"#;
+
+    let mut s = String::new();
+    show_function_definition(&mut s, &function_definition(SRC).unwrap().1);
+
+    assert_eq!(s, DST);
+  }
+
+  #[test]
+  fn test_switch() {
+    use crate::parsers::function_definition;
+
+    const SRC: &'static str = r#"void main() {
+  int i = 10;
+  switch (i) {
+  case 0: { a(); }
+  case 5: { b(); break; }
+  default: break;
+  }
+  switch (i) {
+  case 0:
+    switch (1) {
+    default: break;
+    }
+    break;
+  default: break;
+  }
+}
+"#;
+
+    const DST: &'static str = r#"void main(){int i=10;switch(i){case 0:a();case 5:{b();break;}default:break;}switch(i){case 0:switch(1){default:break;}break;default:break;}}"#;
+
+    let mut s = String::new();
+    show_function_definition(&mut s, &function_definition(SRC).unwrap().1);
+
+    assert_eq!(s, DST);
+  }
+
+  #[test]
   fn roundtrip_glsl_complex_expr() {
     let zero = syntax::Expr::DoubleConst(0.);
     let ray = syntax::Expr::Variable("ray".into());

--- a/glsl/src/transpiler/glsl.rs
+++ b/glsl/src/transpiler/glsl.rs
@@ -1307,15 +1307,17 @@ where
   F: Write,
 {
   show_function_prototype(f, &fd.prototype);
-  show_compound_statement(f, &fd.statement);
+  show_compound_statement(f, &fd.statement, false);
 }
 
-pub fn show_compound_statement<F>(f: &mut F, cst: &syntax::CompoundStatement)
+pub fn show_compound_statement<F>(f: &mut F, cst: &syntax::CompoundStatement, sp: bool)
 where
   F: Write,
 {
   if cst.statement_list.len() != 1 {
     let _ = f.write_str("{");
+  } else if sp {
+    let _ = f.write_str(" ");
   }
 
   for st in &cst.statement_list {
@@ -1328,19 +1330,29 @@ where
 }
 
 pub fn show_statement<F>(f: &mut F, st: &syntax::Statement)
+  where
+      F: Write,
+{
+  show_statement_spaced(f, st, false)
+}
+
+pub fn show_statement_spaced<F>(f: &mut F, st: &syntax::Statement, sp: bool)
 where
   F: Write,
 {
   match *st {
-    syntax::Statement::Compound(ref cst) => show_compound_statement(f, cst),
-    syntax::Statement::Simple(ref sst) => show_simple_statement(f, sst),
+    syntax::Statement::Compound(ref cst) => show_compound_statement(f, cst, sp),
+    syntax::Statement::Simple(ref sst) => show_simple_statement(f, sst, sp),
   }
 }
 
-pub fn show_simple_statement<F>(f: &mut F, sst: &syntax::SimpleStatement)
+pub fn show_simple_statement<F>(f: &mut F, sst: &syntax::SimpleStatement, sp: bool)
 where
   F: Write,
 {
+  if sp {
+    let _ = f.write_str(" ");
+  }
   match *sst {
     syntax::SimpleStatement::Declaration(ref d) => show_declaration(f, d),
     syntax::SimpleStatement::Expression(ref e) => show_expression_statement(f, e),
@@ -1383,8 +1395,8 @@ where
     }
     syntax::SelectionRestStatement::Else(ref if_st, ref else_st) => {
       show_statement(f, if_st);
-      let _ = f.write_str("else ");
-      show_statement(f, else_st);
+      let _ = f.write_str("else");
+      show_statement_spaced(f, else_st, true);
     }
   }
 }
@@ -1433,7 +1445,7 @@ where
     }
     syntax::IterationStatement::DoWhile(ref body, ref cond) => {
       let _ = f.write_str("do");
-      show_statement(f, body);
+      show_statement_spaced(f, body, true);
       let _ = f.write_str("while(");
       show_expr(f, cond);
       let _ = f.write_str(")");
@@ -1813,7 +1825,10 @@ mod tests {
 float n = 0.;
 float p = 0.;
 float u = vec2(0., 0.);
+do p+=0.2;while(p<20);
 if (n-p>0.&&u.y<n&&u.y>p) {
+} else if (u > 0.1) {
+  p = 0.1;
 }
 return u;
 }

--- a/glsl/src/transpiler/glsl.rs
+++ b/glsl/src/transpiler/glsl.rs
@@ -1820,7 +1820,7 @@ return u;
 "#;
 
     // Ideally we would use SRC as the expected, but there's a bug in block braces generation
-    const DST: &'static str = r#"vec2 main(){float n=0.;float p=0.;float u=vec2(0.,0.);if(n-p>0.&&u.y<n&&u.y>p){{}}return u;}"#;
+    const DST: &'static str = r#"vec2 main(){float n=0.;float p=0.;float u=vec2(0.,0.);if(n-p>0.&&u.y<n&&u.y>p){}return u;}"#;
 
     let mut s = String::new();
     show_function_definition(&mut s, &function_definition(SRC).unwrap().1);

--- a/glsl/src/transpiler/glsl.rs
+++ b/glsl/src/transpiler/glsl.rs
@@ -1151,7 +1151,7 @@ where
         show_identifier(f, first);
 
         for identifier in iter {
-          let _ = write!(f, ", {}", identifier);
+          let _ = write!(f, ",{}", identifier);
         }
       }
 

--- a/glsl/src/transpiler/glsl.rs
+++ b/glsl/src/transpiler/glsl.rs
@@ -1825,10 +1825,7 @@ mod tests {
 float n = 0.;
 float p = 0.;
 float u = vec2(0., 0.);
-do p+=0.2;while(p<20);
 if (n-p>0.&&u.y<n&&u.y>p) {
-} else if (u > 0.1) {
-  p = 0.1;
 }
 return u;
 }

--- a/glsl/src/transpiler/glsl.rs
+++ b/glsl/src/transpiler/glsl.rs
@@ -672,7 +672,7 @@ where
     show_type_name(f, first);
 
     for type_name in types_iter {
-      let _ = f.write_str(", ");
+      let _ = f.write_str(",");
       show_type_name(f, type_name);
     }
 
@@ -687,11 +687,11 @@ where
   let mut qualifiers = l.ids.0.iter();
   let first = qualifiers.next().unwrap();
 
-  let _ = f.write_str("layout (");
+  let _ = f.write_str("layout(");
   show_layout_qualifier_spec(f, first);
 
   for qual_spec in qualifiers {
-    let _ = f.write_str(", ");
+    let _ = f.write_str(",");
     show_layout_qualifier_spec(f, qual_spec);
   }
 
@@ -704,7 +704,7 @@ where
 {
   match *l {
     syntax::LayoutQualifierSpec::Identifier(ref i, Some(ref e)) => {
-      let _ = write!(f, "{} = ", i);
+      let _ = write!(f, "{}=", i);
       show_expr(f, &e);
     }
     syntax::LayoutQualifierSpec::Identifier(ref i, None) => show_identifier(f, &i),


### PR DESCRIPTION
Removes printing of unneeded whitespace and unnecessary brackets.

Example Input:
```glsl
#version 150

#moj_import <fog.glsl>

uniform sampler2D Sampler0;

uniform vec4 ColorModulator;
uniform float FogStart;
uniform float FogEnd;
uniform vec4 FogColor;

in float vertexDistance;
in vec4 vertexColor;
in vec2 texCoord0;
in vec2 texCoord1;
in vec4 normal;

out vec4 fragColor;

void main() {
    vec4 color = texture(Sampler0, texCoord0) * vertexColor * ColorModulator;
    if (color.a < 0.1) {
        discard;
    }
    fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
}
```

Old Output:
```glsl
#version 150
#moj_import <fog.glsl>
uniform sampler2D Sampler0;
uniform vec4 ColorModulator;
uniform float FogStart;
uniform float FogEnd;
uniform vec4 FogColor;
in float vertexDistance;
in vec4 vertexColor;
in vec2 texCoord0;
in vec2 texCoord1;
in vec4 normal;
out vec4 fragColor;
void main() {
vec4 color = texture(Sampler0, texCoord0)*vertexColor*ColorModulator;
if (color.a<0.1) {
{
discard;
}
}
fragColor = linear_fog(color, vertexDistance, FogStart, FogEnd, FogColor);
}
```
New Output:
```glsl
#version 150
#moj_import <fog.glsl>
uniform sampler2D Sampler0;uniform vec4 ColorModulator;uniform float FogStart;uniform float FogEnd;uniform vec4 FogColor;in float vertexDistance;in vec4 vertexColor;in vec2 texCoord0;in vec2 texCoord1;in vec4 normal;out vec4 fragColor;void main(){vec4 color=texture(Sampler0,texCoord0)*vertexColor*ColorModulator;if(color.a<0.1)discard;fragColor=linear_fog(color,vertexDistance,FogStart,FogEnd,FogColor);}
```