### PR TITLE
Fix nested if-else syntax errors in some compilers

### DIFF
--- a/glsl/src/transpiler/glsl.rs
+++ b/glsl/src/transpiler/glsl.rs
@@ -1393,7 +1393,7 @@ pub fn show_selection_statement<F>(f: &mut F, sst: &syntax::SelectionStatement, 
 where
   F: Write,
 {
-  if selection && matches!(sst.rest, syntax::SelectionRestStatement::Else(_, _)) {
+  if selection {
     let _ = f.write_str("{");
   } else if sp {
     let _ = f.write_str(" ");
@@ -1418,7 +1418,7 @@ where
     syntax::SelectionRestStatement::Else(ref if_st, ref else_st) => {
       show_statement(f, if_st, true);
       let _ = f.write_str("else");
-      show_statement_spaced(f, else_st, true, true);
+      show_statement_spaced(f, else_st, true, false);
     }
   }
 }

--- a/glsl/src/transpiler/glsl.rs
+++ b/glsl/src/transpiler/glsl.rs
@@ -1393,7 +1393,7 @@ pub fn show_selection_statement<F>(f: &mut F, sst: &syntax::SelectionStatement, 
 where
   F: Write,
 {
-  if selection {
+  if selection && matches!(sst.rest, syntax::SelectionRestStatement::Else(_, _)) {
     let _ = f.write_str("{");
   } else if sp {
     let _ = f.write_str(" ");


### PR DESCRIPTION
This PR works around some GLSL compilers (observed from Apple M1 Pro) giving compilation errors for ambiguous syntax from the aggressive curly bracket removal in nested if-else statements.

Example problematic code which produces `ERROR: 0:14: '}' : syntax error: syntax is ambiguous`:
```glsl
void func() {
    float a = 0.;
    float b = 0.;
    if (a > 0.)
        if (a > 1.) {
            a = 0.;
        } else if (a < 1.) {
            a = 0.;
            b = 3.;
        } else {
            b = 4.;
        }
}
```

This PR maintains all brackets around nested `if` statements, which I found in testing produced acceptable code.
Additionally, I have resolved the extraneous space in `return ;` statements.

The above example would have brackets placed as such with the changes made:
```glsl
void func() {
    float a = 0.;
    float b = 0.;
    if (a > 0.) {
        if (a > 1.)
            a = 0.;
        else if (a < 1.) {
            a = 0.;
            b = 3.;
        } else
            b = 4.;
    }
}
```